### PR TITLE
Fixed the error mentioned in issue #9 (dropping the last line)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Inspired by [vim-isort](https://github.com/fisadev/vim-isort).
 
 - [Isort](https://github.com/timothycrosley/isort) (`pip install isort`).
 - The `isort` command must be on your `PATH`.
+- Make sure that you install the latest version of isort (or at least >=5.7.0)
 
 ## Install
 

--- a/rplugin/python3/isort_nvim.py
+++ b/rplugin/python3/isort_nvim.py
@@ -31,8 +31,9 @@ class IsortNvim:
         buffer = self.nvim.current.buffer
         text = self._get_lines(buffer, range)
         output = self._isort(text, *args)
-        lines = output.split("\n")
-        buffer[range[0] - 1 : range[1]] = lines
+        if text != output:
+            lines = output.split("\n")
+            buffer[range[0] - 1 : range[1]] = lines
 
     def error(self, msg):
         self.nvim.err_write("[isort] {}\n".format(msg))

--- a/rplugin/python3/isort_nvim.py
+++ b/rplugin/python3/isort_nvim.py
@@ -2,58 +2,53 @@ from subprocess import PIPE, Popen
 
 import neovim
 
-ISORT_COMMAND = 'isort'
+ISORT_COMMAND = "isort"
 ISORT_OPTIONS = [
-    '--line-width',
-    '--top',
-    '--future',
-    '--builtin',
-    '--thirdpaty',
-    '--project',
-    '--virtual-env',
-    '--multi-line',
-    '--indent',
-    '--add-import',
-    '--force-adds',
-    '--remove-import',
+    "--line-width",
+    "--top",
+    "--future",
+    "--builtin",
+    "--thirdpaty",
+    "--project",
+    "--virtual-env",
+    "--multi-line",
+    "--indent",
+    "--add-import",
+    "--force-adds",
+    "--remove-import",
 ]
 
 
 @neovim.plugin
 class IsortNvim:
-
     def __init__(self, nvim):
         self.nvim = nvim
 
     @neovim.command(
-        'Isort', nargs='*', range='%',
-        complete='customlist,IsortCompletions')
+        "Isort", nargs="*", range="%", complete="customlist,IsortCompletions"
+    )
     def isort_command(self, args, range):
         buffer = self.nvim.current.buffer
         text = self._get_lines(buffer, range)
         output = self._isort(text, *args)
-        lines = output.split('\n')[:-1]
-        buffer[range[0] - 1:range[1]] = lines
+        lines = output.split("\n")
+        buffer[range[0] - 1 : range[1]] = lines
 
     def error(self, msg):
-        self.nvim.err_write('[isort] {}\n'.format(msg))
+        self.nvim.err_write("[isort] {}\n".format(msg))
 
     def _get_lines(self, buffer, range):
-        lines = buffer[range[0] - 1:range[1]]
-        return '\n'.join(lines)
+        lines = buffer[range[0] - 1 : range[1]]
+        return "\n".join(lines)
 
     def _isort(self, text, *args):
-        isort_command = self.nvim.vars.get('isort_command', ISORT_COMMAND)
-        isort_args = [isort_command] + list(args) + ['-']
+        isort_command = self.nvim.vars.get("isort_command", ISORT_COMMAND)
+        isort_args = [isort_command] + list(args) + ["-"]
         with Popen(isort_args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
             output, error = proc.communicate(input=text.encode())
             return output.decode()
 
-    @neovim.function('IsortCompletions', sync=True)
+    @neovim.function("IsortCompletions", sync=True)
     def isort_completions(self, args):
         arglead, cmdline, cursorpos, *_ = args
-        return [
-            option
-            for option in ISORT_OPTIONS
-            if option.startswith(arglead)
-        ]
+        return [option for option in ISORT_OPTIONS if option.startswith(arglead)]


### PR DESCRIPTION
Removed the [:-1] that was causing the last line to be dropped from the isort output. This change is required as the more recent versions of isort do not append an extra line at the end as the earlier versions used to. I also changed the requirements mentioned in the README to require isort >=5.7.0

close https://github.com/stsewd/isort.nvim/issues/9