### PR TITLE
Fix split for different file formats

### DIFF
--- a/rplugin/python3/isort_nvim.py
+++ b/rplugin/python3/isort_nvim.py
@@ -1,3 +1,4 @@
+import re
 from subprocess import PIPE, Popen
 
 import neovim
@@ -32,7 +33,7 @@ class IsortNvim:
         text = self._get_lines(buffer, range)
         output = self._isort(text, *args)
         if text != output:
-            lines = output.split("\n")
+            lines = re.split(r"\r\n?|\n", output)
             buffer[range[0] - 1 : range[1]] = lines
 
     def error(self, msg):


### PR DESCRIPTION
The current implementation of the extension does not deal with carriage return characters (\r) in other platforms (dos or mac), because the result of isort is split only on \r, leaving the \r characters behind. So, when running it on Windows, the result looks like this:

![image](https://user-images.githubusercontent.com/25110651/223508982-01994c9b-5933-48af-974f-7cc771e762cf.png)

This breaks some other extensions, such as vim-autoformat.

This pull request fixes it by changing the original split to a regex-based one.