### PR TITLE
Make :Isort synchronous

### DIFF
--- a/rplugin/python3/isort_nvim.py
+++ b/rplugin/python3/isort_nvim.py
@@ -25,7 +25,7 @@ class IsortNvim:
         self.nvim = nvim
 
     @neovim.command(
-        "Isort", nargs="*", range="%", complete="customlist,IsortCompletions"
+        "Isort", nargs="*", range="%", complete="customlist,IsortCompletions", sync=True
     )
     def isort_command(self, args, range):
         buffer = self.nvim.current.buffer


### PR DESCRIPTION
The reasons for this are twofold:

- When using :Isort in a BufWritePre autocmd, the :Isort has a chance to (and often does) complete after the write. Which defeats the point of a BufWritePre autocmd.
- If editing a large file, having :Isort run asynchronously means that changes could be made to the file after the command starts but before it completes, this would cause the changes to be overwritten once the command completes.

In general, I do not think it makes sense for :Isort to be asynchronous in most scenarios.

:UpdateRemotePlugins must be ran to correctly apply this change.

---

Please let me know if you would prefer that I add an :IsortSync command as an alternative, instead of modifying the :Isort command. I will make an alternative PR if that's the case.